### PR TITLE
No need for command substitution to show VIRTUAL_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This prompt is based on [gitster] and [basher].
 ## What does it show?
 
 - Red `◼` when last command failed, white otherwise.
+- Python [venv] indicator.
 - Current user. Red if user is root.
 - Current working directory, relative to the git root when in a git repo.
 - Current git branch name, or commit short hash when in ['detached HEAD' state].
@@ -38,10 +39,10 @@ For detailed information, check the [git-info documentation].
 
 Requires Zim's [git-info] module to show git information.
 
-[gitster]: https://github.com/shashankmehta/dotfiles/blob/master/thesetup/zsh/.oh-my-zsh/custom/themes/gitster.zsh-theme
 ['detached head' state]: http://gitfaq.org/articles/what-is-a-detached-head.html
 [git-info documentation]: https://github.com/zimfw/git-info/blob/master/README.md#theming
 [git-info]: https://github.com/zimfw/git-info
 [zim]: https://github.com/zimfw/zimfw
 [gitster]: https://github.com/zimfw/gitster
 [basher]: https://gitlab.com/Spriithy/basher
+[venv]: https://docs.python.org/3/library/venv.html

--- a/oblong.zsh-theme
+++ b/oblong.zsh-theme
@@ -14,6 +14,8 @@ _prompt_basher_pwd() {
   print -n "%F{blue}${current_dir}%b"
 }
 
+VIRTUAL_ENV_DISABLE_PROMPT=1
+
 setopt nopromptbang prompt{cr,percent,sp,subst}
 
 typeset -gA git_info
@@ -28,13 +30,5 @@ if (( ${+functions[git-info]} )); then
   autoload -Uz add-zsh-hook && add-zsh-hook precmd git-info
 fi
 
-_venv() {
-  local venv
-  if ! [[ -z $VIRTUAL_ENV ]]; then
-    venv="($(basename $VIRTUAL_ENV)) "
-  fi
-  print -n "${venv}"
-}
-
-PS1='%(?:%F{white}:%F{red})◼ $(_venv)%(!:%F{red}:%F{white})%n%f%F:$(_prompt_basher_pwd)${(e)git_info[prompt]} %f%(!:#:$) '
+PS1='%(?:%F{white}:%F{red})◼ ${VIRTUAL_ENV:+"(${VIRTUAL_ENV:t}) "}%(!:%F{red}:%F{white})%n%f%F:$(_prompt_basher_pwd)${(e)git_info[prompt]} %f%(!:#:$) '
 RPS1='%(?::%F{red}$?)'


### PR DESCRIPTION
Also mention the Python venv indicator in the README.md, and disable the prompt generated by venv activate script by setting VIRTUAL_ENV_DISABLE_PROMPT.
